### PR TITLE
Add support for USB Host via PIO

### DIFF
--- a/include/port/tusb_config.h
+++ b/include/port/tusb_config.h
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+// #include "pico/stdio_usb.h" // TODO: this pulls in stdio stuff
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Board Specific Configuration
+//--------------------------------------------------------------------+
+
+// change to 1 if using pico-pio-usb as host controller for raspberry rp2040
+#define CFG_TUH_RPI_PIO_USB   1
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+// defined by compiler flags for flexibility
+#ifndef CFG_TUSB_MCU
+#error CFG_TUSB_MCU must be defined
+#endif
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS           OPT_OS_PICO
+#endif
+
+#ifndef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG        1
+#endif
+
+// Enable Device and Host stack
+#define CFG_TUD_ENABLED       1
+#define CFG_TUH_ENABLED       1
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUH_MEM_SECTION
+#define CFG_TUH_MEM_SECTION
+#endif
+
+#ifndef CFG_TUH_MEM_ALIGN
+#define CFG_TUH_MEM_ALIGN        __attribute__ ((aligned(4)))
+#endif
+
+// TODO: I added this from the original... is it ok?
+#define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE)
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+#define CFG_TUD_CDC              (1)
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE   (256) // TODO: these were originally 512, go back?
+#define CFG_TUD_CDC_TX_BUFSIZE   (256) // TODO: these were originally 512, go back?
+#define CFG_TUD_VENDOR           (0)
+
+// CDC Endpoint transfer buffer size, more is faster
+#define CFG_TUD_CDC_EP_BUFSIZE   64
+
+//--------------------------------------------------------------------
+// HOST CONFIGURATION
+//--------------------------------------------------------------------
+
+// Size of buffer to hold descriptors and other data used for enumeration
+#define CFG_TUH_ENUMERATION_BUFSIZE 256
+
+#define CFG_TUH_HUB                 0 // number of supported hubs
+#define CFG_TUH_CDC                 1 // CDC ACM
+#define CFG_TUH_CDC_FTDI            1 // FTDI UART
+#define CFG_TUH_HID                 0
+#define CFG_TUH_MSC                 0
+#define CFG_TUH_VENDOR              0
+
+// max device support (excluding hub device): 1 hub typically has 4 ports
+#define CFG_TUH_DEVICE_MAX          (3*CFG_TUH_HUB + 1)
+
+//------------- CDC -------------//
+
+#define CFG_TUH_CDC_TX_BUFSIZE     512
+#define CFG_TUH_CDC_RX_BUFSIZE     512
+
+// Set Line Control state on enumeration/mounted:
+// DTR ( bit 0), RTS (bit 1)
+#define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM    0x03
+
+// Set Line Coding on enumeration/mounted, value for cdc_line_coding_t
+// bit rate = 115200, 1 stop bit, no parity, 8 bit data width
+#define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 9600, CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/targets/rp2/src/system.c
+++ b/targets/rp2/src/system.c
@@ -95,6 +95,7 @@ void km_system_init() {
   km_uart_init();
   km_rtc_init();
   km_flash_init();
+  // km_tinyusb_init();
 }
 
 void km_system_cleanup() {
@@ -124,4 +125,35 @@ void km_custom_infinite_loop() {
 #ifdef PICO_CYW43
   cyw43_arch_poll();
 #endif /* PICO_CYW43 */
+  // tuh_task();
+  // tud_task();
 }
+
+// // ==[ Move this part to it's own file when Ha says so ]==
+//
+// #include "pio_usb.h"
+// #include "tusb.h"
+//
+// #define BOARD_TUH_RHPORT 1
+//
+// #define PICO_DEFAULT_PIO_USB_DP_PIN       16
+// #define PICO_DEFAULT_PIO_USB_VBUSEN_PIN   22
+// #define PICO_DEFAULT_PIO_USB_VBUSEN_STATE 1
+//
+// void km_usbh_init() {
+//
+//   // Set the system clock to 120MHz
+//   set_sys_clock_khz(120000, true);
+//
+// #ifdef PICO_DEFAULT_PIO_USB_VBUSEN_PIN
+//   gpio_init(PICO_DEFAULT_PIO_USB_VBUSEN_PIN);
+//   gpio_set_dir(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, GPIO_OUT);
+//   gpio_put(PICO_DEFAULT_PIO_USB_VBUSEN_PIN, PICO_DEFAULT_PIO_USB_VBUSEN_STATE);
+// #endif
+//
+//   // Configure the pio state machine to bitbang USB
+//   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
+//   pio_cfg.pin_dp = PICO_DEFAULT_PIO_USB_DP_PIN;
+//   tuh_configure(BOARD_TUH_RHPORT, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);
+//   tuh_init(BOARD_TUH_RHPORT);
+// }

--- a/targets/rp2/src/usb.c
+++ b/targets/rp2/src/usb.c
@@ -30,7 +30,7 @@ static void *chars_available_param;
 #endif
 
 // when tinyusb_device is explicitly linked we do no background tud processing
-#if !LIB_TINYUSB_DEVICE
+// #if !LIB_TINYUSB_DEVICE
 // if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
 // we don't either create multiple one shot timers, or miss creating one. this crit_sec
 // is used to protect the one_shot_timer_pending flag
@@ -89,7 +89,7 @@ static void usb_irq(void) {
     irq_set_pending(low_priority_irq_num);
 }
 
-#endif
+// #endif
 
 static void stdio_usb_out_chars(const char *buf, int length) {
     static uint64_t last_avail_time;
@@ -188,16 +188,16 @@ bool stdio_usb_init(void) {
     bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));
 #endif
 
-#if !defined(LIB_TINYUSB_DEVICE)
+// #if !defined(LIB_TINYUSB_DEVICE)
     // initialize TinyUSB, as user hasn't explicitly linked it
     tusb_init();
-#else
-    assert(tud_inited()); // we expect the caller to have initialized if they are using TinyUSB
-#endif
+// #else
+//     assert(tud_inited()); // we expect the caller to have initialized if they are using TinyUSB
+// #endif
 
     mutex_init(&stdio_usb_mutex);
     bool rc = true;
-#if !LIB_TINYUSB_DEVICE
+// #if !LIB_TINYUSB_DEVICE
 #ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
     user_irq_claim(PICO_STDIO_USB_LOW_PRIORITY_IRQ);
 #else
@@ -215,7 +215,7 @@ bool stdio_usb_init(void) {
         // we use initialization state of the one_shot_timer_critsec as a flag
         memset(&one_shot_timer_crit_sec, 0, sizeof(one_shot_timer_crit_sec));
     }
-#endif
+// #endif
     if (rc) {
         stdio_set_driver_enabled(&stdio_usb, true);
 #if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS

--- a/targets/rp2/src/usb.c
+++ b/targets/rp2/src/usb.c
@@ -253,9 +253,9 @@ bool stdio_usb_init(void) {
     return false;
 }
 #endif // CFG_TUD_ENABLED && CFG_TUD_CDC
-#else
-#warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked
-bool stdio_usb_init(void) {
-    return false;
-}
+// #else
+// #warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked
+// bool stdio_usb_init(void) {
+//     return false;
+// }
 // #endif // !LIB_TINYUSB_HOST

--- a/targets/rp2/src/usb.c
+++ b/targets/rp2/src/usb.c
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// #ifndef LIB_TINYUSB_HOST
+#include "tusb.h"
+#include "pico/stdio_usb.h"
+
+// these may not be set if the user is providing tud support (i.e. LIB_TINYUSB_DEVICE is 1 because
+// the user linked in tinyusb_device) but they haven't selected CDC
+#if (CFG_TUD_ENABLED | TUSB_OPT_DEVICE_ENABLED) && CFG_TUD_CDC
+
+#include "pico/binary_info.h"
+#include "pico/time.h"
+#include "pico/stdio/driver.h"
+#include "pico/mutex.h"
+#include "hardware/irq.h"
+#include "device/usbd_pvt.h" // for usbd_defer_func
+
+static mutex_t stdio_usb_mutex;
+#ifndef NDEBUG
+static uint8_t stdio_usb_core_num;
+#endif
+
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+static void (*chars_available_callback)(void*);
+static void *chars_available_param;
+#endif
+
+// when tinyusb_device is explicitly linked we do no background tud processing
+#if !LIB_TINYUSB_DEVICE
+// if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
+// we don't either create multiple one shot timers, or miss creating one. this crit_sec
+// is used to protect the one_shot_timer_pending flag
+static critical_section_t one_shot_timer_crit_sec;
+static volatile bool one_shot_timer_pending;
+#ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
+static_assert(PICO_STDIO_USB_LOW_PRIORITY_IRQ >= NUM_IRQS - NUM_USER_IRQS, "");
+#define low_priority_irq_num PICO_STDIO_USB_LOW_PRIORITY_IRQ
+#else
+static uint8_t low_priority_irq_num;
+#endif
+
+static int64_t timer_task(__unused alarm_id_t id, __unused void *user_data) {
+    int64_t repeat_time;
+    if (critical_section_is_initialized(&one_shot_timer_crit_sec)) {
+        critical_section_enter_blocking(&one_shot_timer_crit_sec);
+        one_shot_timer_pending = false;
+        critical_section_exit(&one_shot_timer_crit_sec);
+        repeat_time = 0; // don't repeat
+    } else {
+        repeat_time = PICO_STDIO_USB_TASK_INTERVAL_US;
+    }
+    irq_set_pending(low_priority_irq_num);
+    return repeat_time;
+}
+
+static void low_priority_worker_irq(void) {
+    if (mutex_try_enter(&stdio_usb_mutex, NULL)) {
+        tud_task();
+        mutex_exit(&stdio_usb_mutex);
+    } else {
+        // if the mutex is already owned, then we are in non IRQ code in this file.
+        //
+        // it would seem simplest to just let that code call tud_task() at the end, however this
+        // code might run during the call to tud_task() and we might miss a necessary tud_task() call
+        //
+        // if we are using a periodic timer (crit_sec is not initialized in this case),
+        // then we are happy just to wait until the next tick, however when we are not using a periodic timer,
+        // we must kick off a one-shot timer to make sure the tud_task() DOES run (this method
+        // will be called again as a result, and will try the mutex_try_enter again, and if that fails
+        // create another one shot timer again, and so on).
+        if (critical_section_is_initialized(&one_shot_timer_crit_sec)) {
+            bool need_timer;
+            critical_section_enter_blocking(&one_shot_timer_crit_sec);
+            need_timer = !one_shot_timer_pending;
+            one_shot_timer_pending = true;
+            critical_section_exit(&one_shot_timer_crit_sec);
+            if (need_timer) {
+                add_alarm_in_us(PICO_STDIO_USB_TASK_INTERVAL_US, timer_task, NULL, true);
+            }
+        }
+    }
+}
+
+static void usb_irq(void) {
+    irq_set_pending(low_priority_irq_num);
+}
+
+#endif
+
+static void stdio_usb_out_chars(const char *buf, int length) {
+    static uint64_t last_avail_time;
+    if (!mutex_try_enter_block_until(&stdio_usb_mutex, make_timeout_time_ms(PICO_STDIO_DEADLOCK_TIMEOUT_MS))) {
+        return;
+    }
+    if (stdio_usb_connected()) {
+        for (int i = 0; i < length;) {
+            int n = length - i;
+            int avail = (int) tud_cdc_write_available();
+            if (n > avail) n = avail;
+            if (n) {
+                int n2 = (int) tud_cdc_write(buf + i, (uint32_t)n);
+                tud_task();
+                tud_cdc_write_flush();
+                i += n2;
+                last_avail_time = time_us_64();
+            } else {
+                tud_task();
+                tud_cdc_write_flush();
+                if (!stdio_usb_connected() ||
+                    (!tud_cdc_write_available() && time_us_64() > last_avail_time + PICO_STDIO_USB_STDOUT_TIMEOUT_US)) {
+                    break;
+                }
+            }
+        }
+    } else {
+        // reset our timeout
+        last_avail_time = 0;
+    }
+    mutex_exit(&stdio_usb_mutex);
+}
+
+int stdio_usb_in_chars(char *buf, int length) {
+    // note we perform this check outside the lock, to try and prevent possible deadlock conditions
+    // with printf in IRQs (which we will escape through timeouts elsewhere, but that would be less graceful).
+    //
+    // these are just checks of state, so we can call them while not holding the lock.
+    // they may be wrong, but only if we are in the middle of a tud_task call, in which case at worst
+    // we will mistakenly think we have data available when we do not (we will check again), or
+    // tud_task will complete running and we will check the right values the next time.
+    //
+    int rc = PICO_ERROR_NO_DATA;
+    if (stdio_usb_connected() && tud_cdc_available()) {
+        if (!mutex_try_enter_block_until(&stdio_usb_mutex, make_timeout_time_ms(PICO_STDIO_DEADLOCK_TIMEOUT_MS))) {
+            return PICO_ERROR_NO_DATA; // would deadlock otherwise
+        }
+        if (stdio_usb_connected() && tud_cdc_available()) {
+            int count = (int) tud_cdc_read(buf, (uint32_t) length);
+            rc = count ? count : PICO_ERROR_NO_DATA;
+        } else {
+            // because our mutex use may starve out the background task, run tud_task here (we own the mutex)
+            tud_task();
+        }
+        mutex_exit(&stdio_usb_mutex);
+    }
+    return rc;
+}
+
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+void tud_cdc_rx_cb(__unused uint8_t itf) {
+    if (chars_available_callback) {
+        usbd_defer_func(chars_available_callback, chars_available_param, false);
+    }
+}
+
+void stdio_usb_set_chars_available_callback(void (*fn)(void*), void *param) {
+    chars_available_callback = fn;
+    chars_available_param = param;
+}
+#endif
+
+stdio_driver_t stdio_usb = {
+    .out_chars = stdio_usb_out_chars,
+    .in_chars = stdio_usb_in_chars,
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+    .set_chars_available_callback = stdio_usb_set_chars_available_callback,
+#endif
+#if PICO_STDIO_ENABLE_CRLF_SUPPORT
+    .crlf_enabled = PICO_STDIO_USB_DEFAULT_CRLF
+#endif
+
+};
+
+bool stdio_usb_init(void) {
+    if (get_core_num() != alarm_pool_core_num(alarm_pool_get_default())) {
+        // included an assertion here rather than just returning false, as this is likely
+        // a coding bug, rather than anything else.
+        assert(false);
+        return false;
+    }
+#ifndef NDEBUG
+    stdio_usb_core_num = (uint8_t)get_core_num();
+#endif
+#if !PICO_NO_BI_STDIO_USB
+    bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));
+#endif
+
+#if !defined(LIB_TINYUSB_DEVICE)
+    // initialize TinyUSB, as user hasn't explicitly linked it
+    tusb_init();
+#else
+    assert(tud_inited()); // we expect the caller to have initialized if they are using TinyUSB
+#endif
+
+    mutex_init(&stdio_usb_mutex);
+    bool rc = true;
+#if !LIB_TINYUSB_DEVICE
+#ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
+    user_irq_claim(PICO_STDIO_USB_LOW_PRIORITY_IRQ);
+#else
+    low_priority_irq_num = (uint8_t) user_irq_claim_unused(true);
+#endif
+    irq_set_exclusive_handler(low_priority_irq_num, low_priority_worker_irq);
+    irq_set_enabled(low_priority_irq_num, true);
+
+    if (irq_has_shared_handler(USBCTRL_IRQ)) {
+        // we can use a shared handler to notice when there may be work to do
+        irq_add_shared_handler(USBCTRL_IRQ, usb_irq, PICO_SHARED_IRQ_HANDLER_LOWEST_ORDER_PRIORITY);
+        critical_section_init_with_lock_num(&one_shot_timer_crit_sec, next_striped_spin_lock_num());
+    } else {
+        rc = add_alarm_in_us(PICO_STDIO_USB_TASK_INTERVAL_US, timer_task, NULL, true) >= 0;
+        // we use initialization state of the one_shot_timer_critsec as a flag
+        memset(&one_shot_timer_crit_sec, 0, sizeof(one_shot_timer_crit_sec));
+    }
+#endif
+    if (rc) {
+        stdio_set_driver_enabled(&stdio_usb, true);
+#if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS
+#if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS > 0
+        absolute_time_t until = make_timeout_time_ms(PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS);
+#else
+        absolute_time_t until = at_the_end_of_time;
+#endif
+        do {
+            if (stdio_usb_connected()) {
+#if PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS != 0
+                sleep_ms(PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS);
+#endif
+                break;
+            }
+            sleep_ms(10);
+        } while (!time_reached(until));
+#endif
+    }
+    return rc;
+}
+
+bool stdio_usb_connected(void) {
+#if PICO_STDIO_USB_CONNECTION_WITHOUT_DTR
+    return tud_ready();
+#else
+    // this actually checks DTR
+    return tud_cdc_connected();
+#endif
+}
+
+#else
+#warning stdio USB was configured along with user use of TinyUSB device mode, but CDC is not enabled
+bool stdio_usb_init(void) {
+    return false;
+}
+#endif // CFG_TUD_ENABLED && CFG_TUD_CDC
+#else
+#warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked
+bool stdio_usb_init(void) {
+    return false;
+}
+// #endif // !LIB_TINYUSB_HOST

--- a/targets/rp2/target.cmake
+++ b/targets/rp2/target.cmake
@@ -96,6 +96,7 @@ set(CMAKE_OBJCOPY ${PREFIX}objcopy)
 
 set(TARGET_LIBS c nosys m
   pico_stdlib
+  tinyusb_device
   hardware_adc
   hardware_pwm
   hardware_i2c
@@ -124,7 +125,7 @@ include(${CMAKE_SOURCE_DIR}/tools/kaluma.cmake)
 add_executable(${OUTPUT_TARGET} ${SOURCES} ${JERRY_LIBS})
 target_link_libraries(${OUTPUT_TARGET} ${JERRY_LIBS} ${TARGET_LIBS})
 # Enable USB output, disable UART output
-pico_enable_stdio_usb(${OUTPUT_TARGET} 1)
+pico_enable_stdio_usb(${OUTPUT_TARGET} 0)
 pico_enable_stdio_uart(${OUTPUT_TARGET} 0)
 
 pico_add_extra_outputs(${OUTPUT_TARGET})

--- a/targets/rp2/target.cmake
+++ b/targets/rp2/target.cmake
@@ -72,6 +72,7 @@ set(SOURCES
   ${TARGET_SRC_DIR}/i2c.c
   ${TARGET_SRC_DIR}/spi.c
   ${TARGET_SRC_DIR}/rtc.c
+  ${TARGET_SRC_DIR}/usb.c
   ${TARGET_SRC_DIR}/main.c
   ${BOARD_DIR}/board.c)
 
@@ -96,7 +97,13 @@ set(CMAKE_OBJCOPY ${PREFIX}objcopy)
 
 set(TARGET_LIBS c nosys m
   pico_stdlib
+
+  # pico_unique_id
   tinyusb_device
+  # tinyusb_host
+  # tinyusb_pico_pio_usb
+  # pico_fix_rp2040_usb_device_enumeration
+
   hardware_adc
   hardware_pwm
   hardware_i2c
@@ -107,6 +114,10 @@ set(TARGET_LIBS c nosys m
   hardware_rtc
   hardware_sync)
 set(CMAKE_EXE_LINKER_FLAGS "-specs=nano.specs -u _printf_float -Wl,-Map=${OUTPUT_TARGET}.map,--cref,--gc-sections")
+
+target_include_directories(${OUTPUT_TARGET} PUBLIC
+  /Users/shreeve/Data/Code/kaluma/kaluma/lib/pico-sdk/src/rp2_common/pico_stdio_usb/include
+)
 
 # For the pico-w board
 if(BOARD STREQUAL "pico-w")
@@ -124,6 +135,7 @@ endif()
 include(${CMAKE_SOURCE_DIR}/tools/kaluma.cmake)
 add_executable(${OUTPUT_TARGET} ${SOURCES} ${JERRY_LIBS})
 target_link_libraries(${OUTPUT_TARGET} ${JERRY_LIBS} ${TARGET_LIBS})
+
 # Enable USB output, disable UART output
 pico_enable_stdio_usb(${OUTPUT_TARGET} 0)
 pico_enable_stdio_uart(${OUTPUT_TARGET} 0)

--- a/targets/rp2/target.cmake
+++ b/targets/rp2/target.cmake
@@ -115,10 +115,6 @@ set(TARGET_LIBS c nosys m
   hardware_sync)
 set(CMAKE_EXE_LINKER_FLAGS "-specs=nano.specs -u _printf_float -Wl,-Map=${OUTPUT_TARGET}.map,--cref,--gc-sections")
 
-target_include_directories(${OUTPUT_TARGET} PUBLIC
-  /Users/shreeve/Data/Code/kaluma/kaluma/lib/pico-sdk/src/rp2_common/pico_stdio_usb/include
-)
-
 # For the pico-w board
 if(BOARD STREQUAL "pico-w")
   # modules for pico-w
@@ -135,6 +131,10 @@ endif()
 include(${CMAKE_SOURCE_DIR}/tools/kaluma.cmake)
 add_executable(${OUTPUT_TARGET} ${SOURCES} ${JERRY_LIBS})
 target_link_libraries(${OUTPUT_TARGET} ${JERRY_LIBS} ${TARGET_LIBS})
+
+target_include_directories(${OUTPUT_TARGET} PUBLIC
+  /Users/shreeve/Data/Code/kaluma/kaluma/lib/pico-sdk/src/rp2_common/pico_stdio_usb/include
+)
 
 # Enable USB output, disable UART output
 pico_enable_stdio_usb(${OUTPUT_TARGET} 0)


### PR DESCRIPTION
In order to do this, we need to disable the default `stdio_usb` support from the Pico SDK. To preserve that functionality, we will need to bring it over the Kaluma in the file `usb.c`.